### PR TITLE
[FIX] [16.0] Missing entry module_id in data file

### DIFF
--- a/payment_lyra/data/payment_provider_data.xml
+++ b/payment_lyra/data/payment_provider_data.xml
@@ -35,6 +35,7 @@
             <field name="lyra_redirect_success_timeout">5</field>
             <field name="lyra_redirect_error_timeout">5</field>
             <field name="lyra_return_mode">GET</field>
+            <field name="module_id" ref="base.module_payment_lyra"/>
         </record>
 
         <record id="payment_method_lyra" model="account.payment.method">

--- a/payment_lyra/data/payment_provider_data_multi.xml
+++ b/payment_lyra/data/payment_provider_data_multi.xml
@@ -38,6 +38,7 @@
             <field name="lyra_redirect_success_timeout">5</field>
             <field name="lyra_redirect_error_timeout">5</field>
             <field name="lyra_return_mode">GET</field>
+            <field name="module_id" ref="base.module_payment_lyra"/>
         </record>
 
         <record id="payment_method_lyramulti" model="account.payment.method">


### PR DESCRIPTION
Since the rework of Odoo v16, screen views are plugged on module state to manage buttons visibility 
(related to module_id field) :
- buttons to publish/unpublish are not visible
- ribbon are not displayed

https://github.com/odoo/odoo/blob/fb1b607f021b013fdd14aa85a6b82b91d27fa765/addons/payment/views/payment_provider_views.xml#L32C57-L32C57

This PR add the missing data in the file.