### PR TITLE
[FIX] [18.0] Warnings and errors triggered when installing/loading module

### DIFF
--- a/payment_lyra/__manifest__.py
+++ b/payment_lyra/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Lyra Collect Payment Provider',
-    'version': '4.1.0',
+    'version': '18.0.4.1.1',
     'summary': 'Accept payments with Lyra Collect secure payment gateway.',
     'category': 'Accounting/Payment Providers',
     'author': 'Lyra Network',

--- a/payment_lyra/helpers/tools.py
+++ b/payment_lyra/helpers/tools.py
@@ -19,4 +19,4 @@ def find_currency(iso):
     return None
 
 def lang_translate(callback, v):
-    return _(v)
+    return v

--- a/payment_lyra/models/payment_provider.py
+++ b/payment_lyra/models/payment_provider.py
@@ -59,45 +59,45 @@ class ProviderLyra(models.Model):
 
         return doc_field_html
 
-    sign_algo_help = _('Algorithm used to compute the payment form signature. Selected algorithm must be the same as one configured in the Lyra Expert Back Office.')
+    sign_algo_help = 'Algorithm used to compute the payment form signature. Selected algorithm must be the same as one configured in the Lyra Expert Back Office.'
 
     if constants.LYRA_PLUGIN_FEATURES.get('shatwo') == False:
-        sign_algo_help += _('The HMAC-SHA-256 algorithm should not be activated if it is not yet available in the Lyra Expert Back Office, the feature will be available soon.')
+        sign_algo_help += 'The HMAC-SHA-256 algorithm should not be activated if it is not yet available in the Lyra Expert Back Office, the feature will be available soon.'
 
-    providers = [('lyra', _('Lyra Collect - Standard payment'))]
+    providers = [('lyra', 'Lyra Collect - Standard payment')]
     ondelete_policy = {'lyra': 'set default'}
 
     if constants.LYRA_PLUGIN_FEATURES.get('multi') == True:
-        providers.append(('lyramulti', _('Lyra Collect - Payment in installments')))
+        providers.append(('lyramulti', 'Lyra Collect - Payment in installments'))
         ondelete_policy['lyramulti'] = 'set default'
 
     code = fields.Selection(selection_add=providers, ondelete = ondelete_policy)
 
-    lyra_doc = fields.Html(string=_('Click to view the module configuration documentation'), default=lyra_get_doc_field_value(), readonly=True)
-    lyra_site_id = fields.Char(string=_('Shop ID'), help=_('The identifier provided by Lyra Collect.'), default=constants.LYRA_PARAMS.get('SITE_ID'))
-    lyra_key_test = fields.Char(string=_('Key in test mode'), help=_('Key provided by Lyra Collect for test mode (available in Lyra Expert Back Office).'), default=constants.LYRA_PARAMS.get('KEY_TEST'), readonly=constants.LYRA_PLUGIN_FEATURES.get('qualif'))
-    lyra_key_prod = fields.Char(string=_('Key in production mode'), help=_('Key provided by Lyra Collect (available in Lyra Expert Back Office after enabling production mode).'), default=constants.LYRA_PARAMS.get('KEY_PROD'))
-    lyra_sign_algo = fields.Selection(string=_('Signature algorithm'), help=sign_algo_help, selection=[('SHA-1', 'SHA-1'), ('SHA-256', 'HMAC-SHA-256')], default=constants.LYRA_PARAMS.get('SIGN_ALGO'))
-    lyra_notify_url = fields.Char(string=_('Instant Payment Notification URL'), help=_('URL to copy into your Lyra Expert Back Office > Settings > Notification rules.'), default=_get_notify_url, readonly=True)
-    lyra_language = fields.Selection(string=_('Default language'), help=_('Default language on the payment page.'), default=constants.LYRA_PARAMS.get('LANGUAGE'), selection=_get_languages)
-    lyra_available_languages = fields.Many2many('lyra.language', string=_('Available languages'), column1='code', column2='label', help=_('Languages available on the payment page. If you do not select any, all the supported languages will be available.'))
-    lyra_capture_delay = fields.Char(string=_('Capture delay'), help=_('The number of days before the bank capture (adjustable in your Lyra Expert Back Office).'))
-    lyra_validation_mode = fields.Selection(string=_('Validation mode'), help=_('If manual is selected, you will have to confirm payments manually in your Lyra Expert Back Office.'), selection=[('-1', _('Lyra Expert Back Office Configuration')), ('0', _('Automatic')), ('1', _('Manual'))])
-    lyra_payment_cards = fields.Many2many('lyra.card', string=_('Card types'), column1='code', column2='label', help=_('The card type(s) that can be used for the payment. Select none to use gateway configuration.'))
-    lyra_threeds_min_amount = fields.Char(string=_('Manage 3DS'), help=_('Amount below which customer could be exempt from strong authentication. Needs subscription to «Selective 3DS1» or «Frictionless 3DS2» options. For more information, refer to the module documentation.'))
-    lyra_redirect_enabled = fields.Selection(string=_('Automatic redirection'), help=_('If enabled, the buyer is automatically redirected to your site at the end of the payment.'), selection=[('0', _('Disabled')), ('1', _('Enabled'))])
-    lyra_redirect_success_timeout = fields.Char(string=_('Redirection timeout on success'), help=_('Time in seconds (0-300) before the buyer is automatically redirected to your website after a successful payment.'))
-    lyra_redirect_success_message = fields.Char(string=_('Redirection message on success'), help=_('Message displayed on the payment page prior to redirection after a successful payment.'), default=_('Redirection to shop in a few seconds...'))
-    lyra_redirect_error_timeout = fields.Char(string=_('Redirection timeout on failure'), help=_('Time in seconds (0-300) before the buyer is automatically redirected to your website after a declined payment.'))
-    lyra_redirect_error_message = fields.Char(string=_('Redirection message on failure'), help=_('Message displayed on the payment page prior to redirection after a declined payment.'), default=_('Redirection to shop in a few seconds...'))
-    lyra_return_mode = fields.Selection(string=_('Return mode'), help=_('Method that will be used for transmitting the payment result from the payment page to your shop.'), selection=[('GET', 'GET'), ('POST', 'POST')])
+    lyra_doc = fields.Html(string='Click to view the module configuration documentation', default=lyra_get_doc_field_value(), readonly=True)
+    lyra_site_id = fields.Char(string='Shop ID', help='The identifier provided by Lyra Collect.', default=constants.LYRA_PARAMS.get('SITE_ID'))
+    lyra_key_test = fields.Char(string='Key in test mode', help='Key provided by Lyra Collect for test mode (available in Lyra Expert Back Office).', default=constants.LYRA_PARAMS.get('KEY_TEST'), readonly=constants.LYRA_PLUGIN_FEATURES.get('qualif'))
+    lyra_key_prod = fields.Char(string='Key in production mode', help='Key provided by Lyra Collect (available in Lyra Expert Back Office after enabling production mode).', default=constants.LYRA_PARAMS.get('KEY_PROD'))
+    lyra_sign_algo = fields.Selection(string='Signature algorithm', help=sign_algo_help, selection=[('SHA-1', 'SHA-1'), ('SHA-256', 'HMAC-SHA-256')], default=constants.LYRA_PARAMS.get('SIGN_ALGO'))
+    lyra_notify_url = fields.Char(string='Instant Payment Notification URL', help='URL to copy into your Lyra Expert Back Office > Settings > Notification rules.', default=_get_notify_url, readonly=True)
+    lyra_language = fields.Selection(string='Default language', help='Default language on the payment page.', default=constants.LYRA_PARAMS.get('LANGUAGE'), selection=_get_languages)
+    lyra_available_languages = fields.Many2many('lyra.language', string='Available languages', column1='code', column2='label', help='Languages available on the payment page. If you do not select any, all the supported languages will be available.')
+    lyra_capture_delay = fields.Char(string='Capture delay', help='The number of days before the bank capture (adjustable in your Lyra Expert Back Office).')
+    lyra_validation_mode = fields.Selection(string='Validation mode', help='If manual is selected, you will have to confirm payments manually in your Lyra Expert Back Office.', selection=[('-1', 'Lyra Expert Back Office Configuration'), ('0', 'Automatic'), ('1', 'Manual')])
+    lyra_payment_cards = fields.Many2many('lyra.card', string='Card types', column1='code', column2='label', help='The card type(s) that can be used for the payment. Select none to use gateway configuration.')
+    lyra_threeds_min_amount = fields.Char(string='Manage 3DS', help='Amount below which customer could be exempt from strong authentication. Needs subscription to «Selective 3DS1» or «Frictionless 3DS2» options. For more information, refer to the module documentation.')
+    lyra_redirect_enabled = fields.Selection(string='Automatic redirection', help='If enabled, the buyer is automatically redirected to your site at the end of the payment.', selection=[('0', 'Disabled'), ('1', 'Enabled')])
+    lyra_redirect_success_timeout = fields.Char(string='Redirection timeout on success', help='Time in seconds (0-300) before the buyer is automatically redirected to your website after a successful payment.')
+    lyra_redirect_success_message = fields.Char(string='Redirection message on success', help='Message displayed on the payment page prior to redirection after a successful payment.', default='Redirection to shop in a few seconds...')
+    lyra_redirect_error_timeout = fields.Char(string='Redirection timeout on failure', help='Time in seconds (0-300) before the buyer is automatically redirected to your website after a declined payment.')
+    lyra_redirect_error_message = fields.Char(string='Redirection message on failure', help='Message displayed on the payment page prior to redirection after a declined payment.', default='Redirection to shop in a few seconds...')
+    lyra_return_mode = fields.Selection(string='Return mode', help='Method that will be used for transmitting the payment result from the payment page to your shop.', selection=[('GET', 'GET'), ('POST', 'POST')])
     lyra_multi_warning = fields.Boolean(compute='_lyra_compute_multi_warning')
 
-    lyra_multi_count = fields.Char(string=_('Count'), help=_('Installments number'))
-    lyra_multi_period = fields.Char(string=_('Period'), help=_('Delay (in days) between installments.'))
-    lyra_multi_first = fields.Char(string=_('1st installment'), help=_('Amount of first installment, in percentage of total amount. If empty, all installments will have the same amount.'))
+    lyra_multi_count = fields.Char(string='Count', help='Installments number')
+    lyra_multi_period = fields.Char(string='Period', help='Delay (in days) between installments.')
+    lyra_multi_first = fields.Char(string='1st installment', help='Amount of first installment, in percentage of total amount. If empty, all installments will have the same amount.')
 
-    image = fields.Char()
+    image = fields.Char(string="Image (OSB)")
     environment = fields.Char()
 
     lyra_redirect = False

--- a/payment_lyra/models/payment_transaction.py
+++ b/payment_lyra/models/payment_transaction.py
@@ -23,12 +23,12 @@ _logger = logging.getLogger(__name__)
 class TransactionLyra(models.Model):
     _inherit = 'payment.transaction'
 
-    lyra_trans_status = fields.Char(_('Transaction status'))
-    lyra_card_brand = fields.Char(_('Means of payment'))
-    lyra_card_number = fields.Char(_('Card number'))
-    lyra_expiration_date = fields.Char(_('Expiration date'))
-    lyra_auth_result = fields.Char(_('Authorization result'))
-    lyra_raw_data = fields.Text(string=_('Transaction log'), readonly=True)
+    lyra_trans_status = fields.Char('Transaction status')
+    lyra_card_brand = fields.Char('Means of payment')
+    lyra_card_number = fields.Char('Card number')
+    lyra_expiration_date = fields.Char('Expiration date')
+    lyra_auth_result = fields.Char('Authorization result')
+    lyra_raw_data = fields.Text(string='Transaction log', readonly=True)
 
     lyra_html_3ds = fields.Char('3D Secure HTML')
 

--- a/payment_lyra/views/payment_provider_views_multi.xml
+++ b/payment_lyra/views/payment_provider_views_multi.xml
@@ -16,7 +16,7 @@
             <field name="inherit_id" ref="payment.payment_provider_form" />
             <field name="arch" type="xml">
                 <xpath expr="//group[@name='lyra_gateway_access']" position="before">
-                    <field name="lyra_multi_warning" invisible="1"/>
+                    <field name="lyra_multi_warning" invisible="1"/><!--required by OSB -->
                     <div style="background: none repeat scroll 0 0 #FFFFE0; border: 1px solid #E6DB55; font-size: 13px; margin: 0 0 20px; padding: 10px;"
                          invisible="code != 'lyramulti' or lyra_multi_warning == False">
                         <p>


### PR DESCRIPTION
Fix warnings and errors raised when installing or loading the OSB module on an Odoo v18.0 database. 

Concerned warnings are :
- the numerous  "no translation language detected, skipping translation" which are triggered by explicit translations exports where an implicit export is already done
- "Two fields (image, image_128) of payment.provider() have the same label: Image." due to identical label on two payment.provider fields
- The need of an explanation in comment when adding an always invisible field in v18 views. 

The manifest's version number has been updated according to Odoo's coding guidelines, only to point out that these fixes are for v18.0. This number can be changed at convenience. 