### PR TITLE
[FIX] [18.0] Critical error at module install, failing unit test & misc warnings

### DIFF
--- a/payment_lyra/__manifest__.py
+++ b/payment_lyra/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Lyra Collect Payment Provider',
-    'version': '18.0.4.2.1',
+    'version': '18.0.4.2.2',
     'summary': 'Accept payments with Lyra Collect secure payment gateway.',
     'category': 'Accounting/Payment Providers',
     'author': 'Lyra Network',

--- a/payment_lyra/__manifest__.py
+++ b/payment_lyra/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': 'Lyra Collect Payment Provider',
-    'version': '4.2.0',
+    'version': '18.0.4.2.1',
     'summary': 'Accept payments with Lyra Collect secure payment gateway.',
     'category': 'Accounting/Payment Providers',
     'author': 'Lyra Network',

--- a/payment_lyra/__manifest__.py
+++ b/payment_lyra/__manifest__.py
@@ -15,7 +15,7 @@
     'author': 'Lyra Network',
     'website': 'https://www.lyra.com/',
     'license': 'AGPL-3',
-    'depends': ['payment'],
+    'depends': ['payment','sale'],
     'data': [
         'views/payment_provider_views.xml',
         'views/payment_lyra_templates.xml',

--- a/payment_lyra/helpers/constants.py
+++ b/payment_lyra/helpers/constants.py
@@ -38,19 +38,19 @@ LYRA_PARAMS = {
 }
 
 LYRA_LANGUAGES = {
-    'cn': _lt("Chinese"),
-    'de': _lt("German"),
-    'es': _lt("Spanish"),
-    'en': _lt("English"),
-    'fr': _lt("French"),
-    'it': _lt("Italian"),
-    'jp': _lt("Japanese"),
-    'nl': _lt("Dutch"),
-    'pl': _lt("Polish"),
-    'pt': _lt("Portuguese"),
-    'ru': _lt("Russian"),
-    'sv': _lt("Swedish"),
-    'tr': _lt("Turkish"),
+    'cn': "Chinese",
+    'de': "German",
+    'es': "Spanish",
+    'en': "English",
+    'fr': "French",
+    'it': "Italian",
+    'jp': "Japanese",
+    'nl': "Dutch",
+    'pl': "Polish",
+    'pt': "Portuguese",
+    'ru': "Russian",
+    'sv': "Swedish",
+    'tr': "Turkish",
 }
 
 LYRA_CARDS = {

--- a/payment_lyra/helpers/tools.py
+++ b/payment_lyra/helpers/tools.py
@@ -38,7 +38,7 @@ def generate_trans_id():
     return str(delta).rjust(6, '0')
 
 def lang_translate(callback, v):
-    return _(v)
+    return v
 
 def check_hash(post, key):
     return hmac.new(key.encode("utf-8"), eval(json.dumps(post, ensure_ascii=False)).get("kr-answer").encode("utf-8"), hashlib.sha256).hexdigest() == eval(json.dumps(post, ensure_ascii=False)).get("kr-hash")

--- a/payment_lyra/models/payment_provider.py
+++ b/payment_lyra/models/payment_provider.py
@@ -123,7 +123,7 @@ class ProviderLyra(models.Model):
     lyra_embedded_compact_mode = fields.Selection(string='Compact mode', help='This option allows to display the embedded payment fields in a compact mode.', selection=[('0', 'Disabled'), ('1', 'Enabled')], default='0')
     lyra_embedded_payment_attempts = fields.Char(string='Payment attempts number for cards', help='Maximum number of payment by cards retries after a failed payment (between 0 and 2). If blank, the gateway default value is 2.')
 
-    image = fields.Char()
+    image = fields.Char("Image (OSB)")
     environment = fields.Char()
 
     lyra_redirect = False

--- a/payment_lyra/models/payment_provider.py
+++ b/payment_lyra/models/payment_provider.py
@@ -51,6 +51,7 @@ class ProviderLyra(models.Model):
         for provider in self:
             provider.lyra_multi_warning = (constants.LYRA_PLUGIN_FEATURES.get('restrictmulti') == True) if (provider.code == 'lyramulti') else False
 
+    @staticmethod
     def lyra_get_doc_field_value():
         docs_uri = constants.LYRA_ONLINE_DOC_URI
         doc_field_html = ''
@@ -65,7 +66,7 @@ class ProviderLyra(models.Model):
         return [(c, l) for c, l in modes.items()]
 
     def _get_default_entry_mode(self):
-        module_upgrade = request.env['ir.module.module'].search([('state', '=', 'to upgrade'), ('name', '=', 'payment_lyra')])
+        module_upgrade = self.env['ir.module.module'].search([('state', '=', 'to upgrade'), ('name', '=', 'payment_lyra')])
         if module_upgrade:
             return ("redirect")
 
@@ -144,7 +145,7 @@ class ProviderLyra(models.Model):
     @api.model
     def multi_add(self, filename, noupdate):
         if (constants.LYRA_PLUGIN_FEATURES.get('multi') == True):
-            module_upgrade = request.env['ir.module.module'].search([('state', '=', 'to upgrade'), ('name', '=', 'payment_lyra')])
+            module_upgrade = self.env['ir.module.module'].search([('state', '=', 'to upgrade'), ('name', '=', 'payment_lyra')])
             file = path.join(path.dirname(path.dirname(path.abspath(__file__)))) + filename
             mode = 'update' if module_upgrade else 'init'
             convert_xml_import(self.env, 'payment_lyra', file, None, mode, noupdate)
@@ -272,7 +273,7 @@ class ProviderLyra(models.Model):
         return lyra_tx_values
 
     def lyra_generate_values_from_order(self, data):
-        sale_order = request.env['sale.order'].sudo().search([('id', '=', data['order_id'])]).exists()
+        sale_order = self.env['sale.order'].sudo().search([('id', '=', data['order_id'])]).exists()
 
         currency = self._lyra_get_currency(data['currency_id'])
         amount = float(sale_order.amount_total)
@@ -420,7 +421,7 @@ class ProviderLyra(models.Model):
     def _lyra_get_inline_form_values(
         self, amount, currency, partner_id, is_validation, payment_method_sudo, sale_order_id, **kwargs
     ):
-        sale_order = request.env['sale.order'].sudo().search([('id', '=', sale_order_id)]).exists()
+        sale_order = self.env['sale.order'].sudo().search([('id', '=', sale_order_id)]).exists()
         values = {
             "provider_id": self.id,
             "provider_code" : "lyra",

--- a/payment_lyra/views/payment_lyra_templates.xml
+++ b/payment_lyra/views/payment_lyra_templates.xml
@@ -70,7 +70,7 @@
     </template>
 
     <template id="lyra_inline_embedded">
-        <t t-set="payment_provider_model" t-value="request.env['payment.provider'].search([('code', '=', 'lyra')])[0]" />
+        <t t-set="payment_provider_model" t-value="env['payment.provider'].sudo().search([('code', '=', 'lyra')])[0]" />
         <t t-set="inline_form_values"
            t-value="payment_provider_model._lyra_get_inline_form_values(
                amount,

--- a/payment_lyra/views/payment_lyra_templates.xml
+++ b/payment_lyra/views/payment_lyra_templates.xml
@@ -70,7 +70,7 @@
     </template>
 
     <template id="lyra_inline_embedded">
-        <t t-set="payment_provider_model" t-value="env['payment.provider'].sudo().search([('code', '=', 'lyra')])[0]" />
+        <t t-set="payment_provider_model" t-value="request.env['payment.provider'].sudo().search([('code', '=', 'lyra')])[0]" />
         <t t-set="inline_form_values"
            t-value="payment_provider_model._lyra_get_inline_form_values(
                amount,

--- a/payment_lyra/views/payment_provider_views_multi.xml
+++ b/payment_lyra/views/payment_provider_views_multi.xml
@@ -16,7 +16,7 @@
             <field name="inherit_id" ref="payment.payment_provider_form" />
             <field name="arch" type="xml">
                 <xpath expr="//group[@name='lyra_gateway_access']" position="before">
-                    <field name="lyra_multi_warning" invisible="1"/>
+                    <field name="lyra_multi_warning" invisible="1"/><!--required by OSB -->
                     <div style="background: none repeat scroll 0 0 #FFFFE0; border: 1px solid #E6DB55; font-size: 13px; margin: 0 0 20px; padding: 10px;"
                          invisible="code != 'lyramulti' or lyra_multi_warning == False">
                         <p>


### PR DESCRIPTION
Re-implementation of several fixes submitted on v4.1.0 PR that have been forgotten in the v4.2.0, causing regressions and test suite to fail again :
-  Duplicated label for Image field
-  Explanation for always invisible field
-  Unnecessary explicit translations

Also bring some fixes for new version :
- Fix crash at module's installation
- Add missing dependency in manifest
- Fix module's version number to allow upgrade scripts to trigger
- Fix a couple of payment module's unit test fails
